### PR TITLE
Add iPanda

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -653,6 +653,7 @@
 | Cachipum TV | [m3u8](https://tls.cdnz.cl/cachipuntv/live/chunklist_w72379467.m3u8) | [web](http://cachipum.tv/) | [logo](https://graph.facebook.com/cachipumtv/picture?width=200&height=200) | - | - |
 | Mr Bean 24h | [youtube # EN](https://www.youtube.com/channel/UCkAGrHCLFmlK3H2kd6isipg/live) | [web](https://www.mrbean.com/) | [logo](https://graph.facebook.com/MrBean/picture?width=200&height=200) | - | EMB |
 | AKC TV Dogs | [m3u8 # EN # 1](https://video.blivenyc.com/broadcast/prod/2061/22/desktop-playlist.m3u8) - [m3u8 # EN # 2](https://video.blivenyc.com/broadcast/prod/2061/29/desktop-playlist.m3u8) | [web](https://akc.tv/) | [logo](https://graph.facebook.com/WatchAKCTV/picture?width=200&height=200) | - | - |
+| iPanda TV | [m3u8 # ZH # 1](https://gckshwh5c.v.kcdnvip.com/gc/cdrmipanda_1/index.m3u8) - [m3u8 # ZH # 2](https://gckshwc.v.kcdnvip.com/gc/ipanda1000_1/index.m3u8) | [web](https://live.ipanda.com/xmcd/?channelabled=0) | [logo](https://graph.facebook.com/ipandacom/picture?width=200&height=200) | - | - |
 
 ## Deportivos Int.
 


### PR DESCRIPTION
Este pull request añade un canal las 24 horas del día sobre pandas desde un zoológico de China. Las transimisiones son accesibles desde [este](https://live.ipanda.com/xmcd/?channelabled=0) y [este](https://live.ipanda.com/xmwl/xmhd/index.shtml?channelabled=0) enlace (hay más enlaces en vivo pero son temporales). Curiosamente tiene 23 millones de suscriptores en Facebook, sin contar la red social de China.