### PR TITLE
Add Rede Brasil de Televisão

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -628,6 +628,7 @@
 | SBT Interior Brasil | [m3u8 # BR](https://5a1c76baf08c0.streamlock.net/sbtinterior/4cd4a4222eabddfc/master.m3u8) | [web](https://sbtinterior.com/aovivo/) | [logo](https://graph.facebook.com/sbtnointerior/picture?width=200&height=200) | - | - |
 | Record News Brasil | [youtube # BR](https://www.youtube.com/channel/UCuiLR4p6wQ3xLEm15pEn1Xw/live) | [web](https://noticias.r7.com/record-news) | [logo](https://graph.facebook.com/recordnews/picture?width=200&height=200) | - | EMB |
 | Rede Massa Brasil | [m3u8 # BR](https://cdn-cdn-iguacu.ciclano.io:1443/cdn-iguacu/cdn-iguacu/master.m3u8) | [web](https://www.redemassa.com.br/aovivo/) | [logo](https://graph.facebook.com/RedeMassaOficial/picture?width=200&height=200) | - | - |
+| Rede Brasil de Televisão | [m3u8 # BR](https://59f2354c05961.streamlock.net:1443/rbtv/_definst_/rbtv/playlist.m3u8) | [web](https://rbtv.com.br/) | [logo](https://graph.facebook.com/oficialrbtv/picture?width=200&height=200) | - | - |
 
 ## Int. Asia
 


### PR DESCRIPTION
Este PR añade la [señal nacional de RBTV](https://pt.wikipedia.org/wiki/Rede_Brasil_de_Televis%C3%A3o), canal de variedad.