### PR TITLE
ADD Onda Cero (TELEVISION.md)

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -98,6 +98,7 @@
 | Radio Nacional | [m3u8](https://hlsliveamdgl0-lh.akamaihd.net/i/hlslive_1@586409/master.m3u8) | [web](https://www.rtve.es/play/radio/) | [logo](https://graph.facebook.com/radionacionalrne/picture?width=200&height=200) | - | - |
 | Radio 3 | [m3u8](https://ztnr.rtve.es/ztnr/2795617.m3u8) | [web](https://www.rtve.es/play/radio/) | [logo](https://graph.facebook.com/radio3/picture?width=200&height=200) | - | - |
 | Del 40 al 1 | [m3u8](https://prisaradio-live.prisasd.com/live-content/directo40al1/master.m3u8) | [web](https://del40al1.los40.com) | [logo](https://graph.facebook.com/del40al1/picture?width=200&height=200) | - | - |
+| Onda Cero | [m3u8](https://live-estudio.ondacero.es/estudio_oc-pull/video/master.m3u8) | [web](https://www.melodia-fm.com/programas/como-perro-gato/) | [logo](https://graph.facebook.com/ondacero/picture?width=200&height=200) | - | - |
 
 ## Autonómicos
 

--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -98,7 +98,7 @@
 | Radio Nacional | [m3u8](https://hlsliveamdgl0-lh.akamaihd.net/i/hlslive_1@586409/master.m3u8) | [web](https://www.rtve.es/play/radio/) | [logo](https://graph.facebook.com/radionacionalrne/picture?width=200&height=200) | - | - |
 | Radio 3 | [m3u8](https://ztnr.rtve.es/ztnr/2795617.m3u8) | [web](https://www.rtve.es/play/radio/) | [logo](https://graph.facebook.com/radio3/picture?width=200&height=200) | - | - |
 | Del 40 al 1 | [m3u8](https://prisaradio-live.prisasd.com/live-content/directo40al1/master.m3u8) | [web](https://del40al1.los40.com) | [logo](https://graph.facebook.com/del40al1/picture?width=200&height=200) | - | - |
-| Onda Cero | [m3u8](https://live-estudio.ondacero.es/estudio_oc-pull/video/master.m3u8) | [web](https://www.melodia-fm.com/programas/como-perro-gato/) | [logo](https://graph.facebook.com/ondacero/picture?width=200&height=200) | - | - |
+| Onda Cero | [m3u8](https://live-estudio.ondacero.es/estudio_oc-pull/video/master.m3u8) | [web](https://www.ondacero.es/) | [logo](https://graph.facebook.com/ondacero/picture?width=200&height=200) | - | - |
 
 ## Autonómicos
 


### PR DESCRIPTION
El stream **FUNCIONA 24 h** . NO sale en la web el reproductor con este directo siempre, pero cuando hay partidos especiales en **Radioestadio** lo dan en la web mediante este m3u8 . También los fines de semana: S-15:00 y D-14:30 se puede ver aquí un programa que hay y  a través del canal YouTube. En la web de Onda Cero solo aparece este m3u8 con su reproductor cuando hay programas especiales. Un saludo😘😃