### PR TITLE
Update Onda Cero (TV)

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -95,8 +95,7 @@
 | flooxer | - | [web](https://www.atresplayer.com/directos/flooxer/) | [logo](https://graph.facebook.com/flooxer/picture?width=200&height=200) | - | W3U,EMB,EXTA |
 | Radio Nacional | [m3u8](https://ztnr.rtve.es/ztnr/1938076.m3u8) | [web](https://www.rtve.es/play/radio/) | [logo](https://graph.facebook.com/radionacionalrne/picture?width=200&height=200) | - | - |
 | Radio 3 | [m3u8](https://ztnr.rtve.es/ztnr/2795617.m3u8) | [web](https://www.rtve.es/play/radio/) | [logo](https://graph.facebook.com/radio3/picture?width=200&height=200) | - | - |
-| Onda Cero | [m3u8](https://live-estudio.ondacero.es/estudio_oc-pull/video/master.m3u8) | [web](https://www.ondacero.es) | [logo](https://graph.facebook.com/ondacero/picture?width=200&height=200) | - | - |
-| Del 40 al 1 | [m3u8](https://prisaradio-live.prisasd.com/live-content/directo40al1/master.m3u8) | [web](https://del40al1.los40.com) | [logo](https://graph.facebook.com/del40al1/picture?width=200&height=200) | - | - |
+| Onda Cero | [youtube](https://www.youtube.com/channel/UCPd-Lf5gQkAJD5XdTmT_GGA/live) | [web](https://www.ondacero.es/) | [logo](https://graph.facebook.com/ondacero/picture?width=200&height=200) | - | EMB |l1/master.m3u8) | [web](https://del40al1.los40.com) | [logo](https://graph.facebook.com/del40al1/picture?width=200&height=200) | - | - |
 | COPE | [m3u8](https://hls-directo01-cope-stream.flumotion.com/playlist.m3u8) | [web](https://www.cope.es/directos/video) | [logo](https://graph.facebook.com/COPE/picture?width=200&height=200) | - | - |
 
 ## Streaming

--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -96,6 +96,7 @@
 | Radio Nacional | [m3u8](https://ztnr.rtve.es/ztnr/1938076.m3u8) | [web](https://www.rtve.es/play/radio/) | [logo](https://graph.facebook.com/radionacionalrne/picture?width=200&height=200) | - | - |
 | Radio 3 | [m3u8](https://ztnr.rtve.es/ztnr/2795617.m3u8) | [web](https://www.rtve.es/play/radio/) | [logo](https://graph.facebook.com/radio3/picture?width=200&height=200) | - | - |
 | Onda Cero | [youtube](https://www.youtube.com/channel/UCPd-Lf5gQkAJD5XdTmT_GGA/live) | [web](https://www.ondacero.es/) | [logo](https://graph.facebook.com/ondacero/picture?width=200&height=200) | - | EMB |l1/master.m3u8) | [web](https://del40al1.los40.com) | [logo](https://graph.facebook.com/del40al1/picture?width=200&height=200) | - | - |
+| Del 40 al 1 | [m3u8](https://prisaradio-live.prisasd.com/live-content/directo40al1/master.m3u8) | [web](https://del40al1.los40.com) | [logo](https://graph.facebook.com/del40al1/picture?width=200&height=200) | - | - |
 | COPE | [m3u8](https://hls-directo01-cope-stream.flumotion.com/playlist.m3u8) | [web](https://www.cope.es/directos/video) | [logo](https://graph.facebook.com/COPE/picture?width=200&height=200) | - | - |
 
 ## Streaming


### PR DESCRIPTION
El m3u8 ya NO funciona y cuando tienen que emitir algún evento lo hacen por YouTube y NO por el m3u8.