### PR TITLE
Replace Hoy Jerez By 101TV Cádiz

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -171,7 +171,7 @@
 | CostadelSol TV | [m3u8](https://limited11.todostreaming.es/live/benalmadena-livestream.m3u8) | [web](http://www.costadelsoltv.es) | [logo](https://graph.facebook.com/costadelsoltv/picture?width=200&height=200) | - | - |
 | Bailén TV | [m3u8 # 1](http://cpd.bailen.tv:8080/Playlist_CANAL_24H/playlist.m3u8) - [m3u8 # 2](http://cpd.bailen.tv:8080/Directos/index.m3u8) | [web](http://bailen.tv) | [logo](https://graph.facebook.com/BailenTv/picture?width=200&height=200) | - | - |
 | 101TV Antequera | [m3u8](https://limited38.todostreaming.es/live/101tv-AntequeraHD.m3u8) | [web](https://www.101tv.es/directo-antequera/) | [logo](https://graph.facebook.com/101tvAntequera/picture?width=200&height=200) | 101Antequera.TV | - |
-| Hoy Jerez | [m3u8](https://cloudvideo.servers10.com:8081/8210/index.m3u8) | [web](https://hoyjerez.com) | [logo](https://graph.facebook.com/hoyjerezdiario/picture?width=200&height=200) | - | - |
+| 101TV Cádiz | [m3u8](https://streaming101tv.es/hls/webcadiz.m3u8) | [web](https://www.101tvcadiz.es/directo/) | [logo](https://graph.facebook.com/101tvAntequera/picture?width=200&height=200) | - | - |
 | Sal TV | [m3u8](https://cloudvideo.servers10.com:8081/8254/index.m3u8) | [web](https://saltv.es) | [logo](https://graph.facebook.com/SalTelevision/picture?width=200&height=200) | - | - |
 | 9 la Loma TV | [m3u8](https://9laloma.tv/live.m3u8) | [web](https://9laloma.tv/directo/) | [logo](https://graph.facebook.com/9laloma/picture?width=200&height=200) | 9LaLoma.TV | - |
 | Vivamóvil TV | [m3u8](https://5d8d85cf2c308.streamlock.net:1936/AlcalaTV/endirecto/playlist.m3u8) | [web](https://vivamovil.es/vivamoviltv) | [logo](https://pbs.twimg.com/profile_images/1401880197578870789/_8jMKpKE_200x200.jpg) | - | - |


### PR DESCRIPTION
8tv Jerez deja de emitir a través de su señal habitual y se suma a la parrilla de 101tv Andalucía en la provincia de Cádiz. Gracias a esta nueva sinergia los gaditanos y jerezanos disfrutan de los mejores programas de entretenimiento, actualidad, análisis, información, cofradías, gastronomía y tauromaquia