### PR TITLE
Rename  Canal Extremadura Toros to Canal Extremadura WEB

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -409,7 +409,7 @@
 | Canal | M3U8 | Web | Logo | EPG ID | Info |
 | - | - | - | - | - | - |
 | Canal Extremadura | [m3u8](https://cdnlive.codev8.net/canalextremaduralive/smil:channel1DVR.smil/playlist.m3u8?DVR) | [web](https://www.canalextremadura.es/directo/television) | [logo](https://graph.facebook.com/CanalExtremadura/picture?width=200&height=200) | Extremadura.TV | - |
-| Canal Extremadura Toros | [m3u8](https://cdnlive.codev8.net/canalextremaduralive/smil:channel5.smil/playlist.m3u8) | [web](https://www.canalextremadura.es/directo/web) | [logo](https://www.canalextremadura.es/sites/default/files/styles/medium/public/Media/Images/2022-03/logo-toros.jpg) | - | - |
+| Canal Extremadura WEB | [m3u8](https://cdnlive.codev8.net/canalextremaduralive/smil:channel5.smil/playlist.m3u8) | [web](https://www.canalextremadura.es/directo/web) | [logo](https://graph.facebook.com/CanalExtremadura/picture?width=200&height=200)) | - | - |
 | TV Extremeña | [stream](https://player.twitch.tv/?channel=tvextremena&parent=tdtchannels.com&parent=www.tdtchannels.com) | [web](https://www.xn--televisionextremea-30b.com/directo/) | [logo](https://graph.facebook.com/TELEVISIONEXTREMENA/picture?width=200&height=200) | - | EMB |
 | Nuestra Comarca TV | [stream](https://player.twitch.tv/?channel=nuestracomarcatelevision&parent=tdtchannels.com&parent=www.tdtchannels.com) | [web](https://www.nuestracomarca.com) | [logo](https://graph.facebook.com/nuestra.comarca/picture?width=200&height=200) | - | EMB |
 | Zafra TV | [m3u8](https://cloud.fastchannel.es/mic/manifiest/hls/radiotvzafra/radiotvzafra.m3u8) | [web](https://webtv.radiotvzafra.es) | [logo](https://graph.facebook.com/ZFtelevision/picture?width=200&height=200) | - | REFG1 |

--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -408,8 +408,7 @@
 
 | Canal | M3U8 | Web | Logo | EPG ID | Info |
 | - | - | - | - | - | - |
-| Canal Extremadura | [m3u8](https://cdnlive.codev8.net/canalextremaduralive/smil:channel1DVR.smil/playlist.m3u8?DVR) | [web](https://www.canalextremadura.es/directo/television) | [logo](https://graph.facebook.com/CanalExtremadura/picture?width=200&height=200) | Extremadura.TV | - |
-| Canal Extremadura WEB | [m3u8](https://cdnlive.codev8.net/canalextremaduralive/smil:channel5.smil/playlist.m3u8) | [web](https://www.canalextremadura.es/directo/web) | [logo](https://graph.facebook.com/CanalExtremadura/picture?width=200&height=200)) | - | - |
+| Canal Extremadura | [m3u8 # 1](https://cdnlive.codev8.net/canalextremaduralive/smil:channel1DVR.smil/playlist.m3u8?DVR) - [m3u8 # 2](https://cdnlive.codev8.net/canalextremaduralive/smil:channel5.smil/playlist.m3u8) | [web](https://www.canalextremadura.es/directo/television) | [logo](https://graph.facebook.com/CanalExtremadura/picture?width=200&height=200) | Extremadura.TV | - |
 | TV Extremeña | [stream](https://player.twitch.tv/?channel=tvextremena&parent=tdtchannels.com&parent=www.tdtchannels.com) | [web](https://www.xn--televisionextremea-30b.com/directo/) | [logo](https://graph.facebook.com/TELEVISIONEXTREMENA/picture?width=200&height=200) | - | EMB |
 | Nuestra Comarca TV | [stream](https://player.twitch.tv/?channel=nuestracomarcatelevision&parent=tdtchannels.com&parent=www.tdtchannels.com) | [web](https://www.nuestracomarca.com) | [logo](https://graph.facebook.com/nuestra.comarca/picture?width=200&height=200) | - | EMB |
 | Zafra TV | [m3u8](https://cloud.fastchannel.es/mic/manifiest/hls/radiotvzafra/radiotvzafra.m3u8) | [web](https://webtv.radiotvzafra.es) | [logo](https://graph.facebook.com/ZFtelevision/picture?width=200&height=200) | - | REFG1 |


### PR DESCRIPTION
Cambio el nombre porque creo que alguien nos metió un gol, esta emisión especial web es solamente utilizada ocasionalmente, para eventos especiales. No es solo para retrasmitir Toros