### PR TITLE
Añadir Radio Calima TV (Canarias)

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -250,6 +250,7 @@
 | Noroeste TV | [m3u8](https://stream.castr.com/5d1f649bed75c92e40481734/live_19364d50fbcd11ed91bd012c3488eabc/index.fmp4.m3u8) | [web](https://sites.google.com/view/noroestetv/inicio) | [logo](https://graph.facebook.com/noroestetvladesiempre/picture?width=200&height=200) | - | NONAV,REFC1 |
 | Factoría de Carnaval | [m3u8](https://eu1.servers10.com:8081/8116/index.m3u8) | [web](https://multicarnaval.com) | [logo](https://pbs.twimg.com/profile_images/1498617906560737281/iOri7Ujk_200x200.jpg) | - | - |
 | Afortunadas TV | [m3u8](https://cloudvideo.servers10.com:8081/8108/index.m3u8) | [web](https://www.afortunadastv.com) | [logo](https://graph.facebook.com/afortunadastv/picture?width=200&height=200) | - | - |
+| Radio Calima TV | [m3u8](https://nrvideo1.newradio.it:443/calimafm/calimafm/playlist.m3u8) | [web](https://calima.fm/es/) | [logo](https://graph.facebook.com/calimafm/picture?width=200&height=200) | - | - |
 | Parlamento de Canarias | [youtube](https://www.youtube.com/channel/UCv7xnuWoLWJNEXNWIGkP19g/live) | [web](https://www.parcan.es) | [logo](https://graph.facebook.com/parlamentodecanarias/picture?width=200&height=200) | - | EMB |
 | Gobierno de Canarias | [youtube](https://www.youtube.com/channel/UCOfVTY15POTQM37WNlHRCgQ/live) | [web](https://www.gobiernodecanarias.org/presidencia/) | [logo](https://graph.facebook.com/PRES.Gobcan/picture?width=200&height=200) | - | EMB |
 


### PR DESCRIPTION
Radio Calima es una emisora que emite desde Maspalomas (Gran Canaria) con programación dedicada a la diáspora italiana.