### PR TITLE
Remove California Music Channel

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -841,7 +841,6 @@
 | Ditty TV USA | [m3u8 # EN](https://0ba805a2403b4660bbb05c0a210ebbdc.mediatailor.us-east-1.amazonaws.com/v1/master/04fd913bb278d8775298c26fdca9d9841f37601f/ONO_DittyTV/playlist.m3u8) | [web](https://dittytv.com/watch/) | [logo](https://graph.facebook.com/DittyTV/picture?width=200&height=200) | - | - |
 | RadioU TV USA | [m3u8 # EN](https://1826200335.rsc.cdn77.org/1826200335/index.m3u8) | [web](https://radiou.com/tv/) | [logo](https://graph.facebook.com/RadioU/picture?width=200&height=200) | - | REF,NONAV |
 | Retro Plus TV Chile | [m3u8](https://scl.edge.grupoz.cl/retroplustvuno/live/playlist.m3u8) | [web](https://www.retroplustv.com/#se%C3%B1ales) | [logo](https://graph.facebook.com/retroplustv/picture?width=200&height=200) | - | - |
-| California Music Channel USA | [m3u8 # EN](https://cmc-ono.amagi.tv/hls/amagi_hls_data_cmcAAAAAA-cmc-ono/CDN/playlist.m3u8?device=TDTChannels) | [web](https://www.cmc-tv.com) | [logo](https://graph.facebook.com/CaliforniaMusicChannel/picture?width=200&height=200) | - | - |
 | Portal Foxmix Chile | [m3u8](https://panel.tvstream.cl:1936/8040/8040/playlist.m3u8) | [web](https://www.portalfoxmix.cl/tv/) | [logo](https://yt3.ggpht.com/ytc/AAUvwnj90kC8kqjZ69oiVT718JUs9iedB5o1w9cKfApo=s200) | - | - |
 | Spirit TV USA | [m3u8 # EN](https://cdnlive.myspirit.tv/LS-ATL-43240-2/index.m3u8) | [web](https://myspirit.tv) | [logo](https://graph.facebook.com/MySpirittv/picture?width=200&height=200) | - | - |
 


### PR DESCRIPTION
CMC Live is no longer available on the website.
Please download the free CMC App to your
Apple TV, Amazon Fire TV or Firestick,
Google/Android TV, Roku or mobile device today!