### PR TITLE
Remove Distrito TV from C. Val.

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -455,7 +455,6 @@
 | Levante TV | [stream](https://player.twitch.tv/?channel=levante_tv&parent=play.tdtchannels.com) | [web](https://www.levante-emv.com/videos/levante-tv) | [logo](https://graph.facebook.com/levantetv/picture?width=200&height=200) | Levante.TV | EMB |
 | Burriana TV | [m3u8](https://stream.burrianateve.com/hls/abr_btv/index.m3u8) | [web](https://burrianateve.com) | [logo](https://graph.facebook.com/burrianateve/picture?width=200&height=200) | - | - |
 | TV 4 La Vall | [m3u8](https://valldeuxo.gestec-video.com/hls/lavall.m3u8) | [web](https://valldeuxo.gestec-video.com/lavall.php) | [logo](https://graph.facebook.com/TV4LaVall/picture?width=200&height=200) | - | NONAV |
-| Distrito TV | [m3u8](https://live.emitstream.com/hls/3mn7wpcv7hbmxmdzaxap/master.m3u8) | [web](https://eldistrito.es/distrito-tv/) | [logo](https://graph.facebook.com/2004860103163343/picture?width=200&height=200) | Distrito.TV | - |
 | Canal 56 | [m3u8](https://videos.canal56.com/directe/stream/index.m3u8) | [web](https://canal56.com/online/) | [logo](https://graph.facebook.com/canal56televisio/picture?width=200&height=200) | - | NONAV |
 | Tele Safor | [m3u8](https://video.telesafor.com/hls/video.m3u8) | [web](https://telesafor.com) | [logo](https://graph.facebook.com/Telesaforcom/picture?width=200&height=200) | - | - |
 | Univers TV | [m3u8](https://cloud2.streaminglivehd.com:1936/universfaller/universfaller/playlist.m3u8) | [web](https://www.universvalencia.es) | [logo](https://graph.facebook.com/UniversValenciaDigital/picture?width=200&height=200) | - | - |


### PR DESCRIPTION
## Información general
<!-- Explica brevemente qué canal o emisora quieres añadir, modificar o eliminar. Opcional. -->
Distrito TV is currently not broadcasting in the País Valencià. Its [official website](https://distritotv.es/quienes-somos-distrito-tv/) only lists frequencies for Madrid Capital, Pozuelo de Alarcón and Móstoles, even though the map also highlights the provinces of Valencia, Castellón and Alicante, as well as Pontevedra, A Coruña, Lugo and Ourense, and we don't have the capital duplicated in the Galicia section either.

On top of that, muxTDT doesn't list Distrito TV in the TDT frequencies for [Valencia](https://www.muxtdt.com/canales-valencia) or [A Coruña](https://www.muxtdt.com/canales-coruna) either.

## Campos afectados
<!-- Marca todos los campos que se modifican. Requerido. -->
* [X] Nombre
* [X] Stream
* [X] Web
* [X] Logo
* [X] EPG
* [x] Info

## Origen de la emisión
<!-- Marca al menos una opción. Este apartado es obligatorio si añades o modificas un Stream. -->

* [x] Sitio web oficial
* [ ] Plataforma de terceros cuyo origen es oficial
* [ ] Plataforma de terceros cuyo origen desconozco
* [ ] Origen desconocido
* [ ] Otro origen:

### Validación del Stream
<!-- Obligatorio si añades o modificas un Stream. Indica cómo has comprobado que funciona y, si es posible, en qué reproductor o dispositivo. -->

## Información adicional
<!-- Añade cualquier observación que pueda resultar útil durante la revisión. Opcional. -->

<!-- Recuerda haber leído la guía de contribuciones https://github.com/LaQuay/TDTChannels/blob/master/CONTRIBUTING.md -->
