### PR TITLE
Update Castilla-La Mancha Media channels naming

### DIFF
--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -300,8 +300,8 @@
 
 | Canal | M3U8 | Web | Logo | EPG ID | Info |
 | - | - | - | - | - | - |
-| Castilla-La Mancha Media | [m3u8](https://cdnapisec.kaltura.com/p/2288691/sp/228869100/playManifest/entryId/1_gnz6ity9/protocol/https/format/applehttp/a.m3u8) | [web](https://www.cmmedia.es/play/en-directo/tv) | [logo](https://graph.facebook.com/CMMediaes/picture?width=200&height=200) | CMM.TV | - |
-| Castilla-La Mancha Radio | [m3u8](https://cdnapisec.kaltura.com/p/2288691/sp/228869100/playManifest/entryId/1_fmx3e3sd/protocol/https/format/applehttp/a.m3u8) | [web](https://www.cmmedia.es/play/en-directo/radio/emision-visual-radio-c-lm.html) | [logo](https://graph.facebook.com/RadioCLMes/picture?width=200&height=200) | - | - |
+| CMM TV | [m3u8](https://cdnapisec.kaltura.com/p/2288691/sp/228869100/playManifest/entryId/1_gnz6ity9/protocol/https/format/applehttp/a.m3u8) | [web](https://www.cmmedia.es/play/en-directo/tv) | [logo](https://graph.facebook.com/CMMediaes/picture?width=200&height=200) | CMM.TV | - |
+| CMM Radio | [m3u8](https://cdnapisec.kaltura.com/p/2288691/sp/228869100/playManifest/entryId/1_fmx3e3sd/protocol/https/format/applehttp/a.m3u8) | [web](https://www.cmmedia.es/play/en-directo/radio/emision-visual-radio-c-lm.html) | [logo](https://graph.facebook.com/RadioCLMes/picture?width=200&height=200) | - | - |
 | Visión 6 TV | [stream](https://streaming.proceso.info:8888/vision6-web/stream.m3u8) | [web](https://www.visionseis.tv/tv-online-vision-seis/) | [logo](https://graph.facebook.com/104927246235553/picture?width=200&height=200) | Vision6.TV | EMB |
 | TV Hellín | [m3u8](https://5940924978228.streamlock.net/directohellin/directohellin/playlist.m3u8) | [web](https://televisionhellin.com/tvhellindirecto.html) | [logo](https://graph.facebook.com/tvhellin/picture?width=200&height=200) | - | - |
 | Guada TV Media | [m3u8](https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=12689&live=1) | [web](https://www.guadatv.tv/streaming/) | [logo](https://graph.facebook.com/GuadaTV.TV/picture?width=200&height=200) | - | - |

--- a/TELEVISION.md
+++ b/TELEVISION.md
@@ -300,8 +300,8 @@
 
 | Canal | M3U8 | Web | Logo | EPG ID | Info |
 | - | - | - | - | - | - |
-| CMM TV | [m3u8](https://cdnapisec.kaltura.com/p/2288691/sp/228869100/playManifest/entryId/1_gnz6ity9/protocol/https/format/applehttp/a.m3u8) | [web](https://www.cmmedia.es/play/en-directo/tv) | [logo](https://graph.facebook.com/CMMediaes/picture?width=200&height=200) | CMM.TV | - |
-| CMM Radio | [m3u8](https://cdnapisec.kaltura.com/p/2288691/sp/228869100/playManifest/entryId/1_fmx3e3sd/protocol/https/format/applehttp/a.m3u8) | [web](https://www.cmmedia.es/play/en-directo/radio/emision-visual-radio-c-lm.html) | [logo](https://graph.facebook.com/RadioCLMes/picture?width=200&height=200) | - | - |
+| Castilla-La Mancha Media (CMM) | [m3u8](https://cdnapisec.kaltura.com/p/2288691/sp/228869100/playManifest/entryId/1_gnz6ity9/protocol/https/format/applehttp/a.m3u8) | [web](https://www.cmmedia.es/play/en-directo/tv) | [logo](https://graph.facebook.com/CMMediaes/picture?width=200&height=200) | CMM.TV | - |
+| Castilla-La Mancha Radio (CMM) | [m3u8](https://cdnapisec.kaltura.com/p/2288691/sp/228869100/playManifest/entryId/1_fmx3e3sd/protocol/https/format/applehttp/a.m3u8) | [web](https://www.cmmedia.es/play/en-directo/radio/emision-visual-radio-c-lm.html) | [logo](https://graph.facebook.com/RadioCLMes/picture?width=200&height=200) | - | - |
 | Visión 6 TV | [stream](https://streaming.proceso.info:8888/vision6-web/stream.m3u8) | [web](https://www.visionseis.tv/tv-online-vision-seis/) | [logo](https://graph.facebook.com/104927246235553/picture?width=200&height=200) | Vision6.TV | EMB |
 | TV Hellín | [m3u8](https://5940924978228.streamlock.net/directohellin/directohellin/playlist.m3u8) | [web](https://televisionhellin.com/tvhellindirecto.html) | [logo](https://graph.facebook.com/tvhellin/picture?width=200&height=200) | - | - |
 | Guada TV Media | [m3u8](https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=12689&live=1) | [web](https://www.guadatv.tv/streaming/) | [logo](https://graph.facebook.com/GuadaTV.TV/picture?width=200&height=200) | - | - |


### PR DESCRIPTION
## Información general
<!-- Explica brevemente qué canal o emisora quieres añadir, modificar o eliminar. Opcional. -->Castilla-La Mancha Media refers to the radio and television broadcaster in Castilla-La Mancha, not the television channel.
The TV channel is called `CMM TV` and the radio station is called `CMM Radio`.
We have therefore also standardised the name of the radio station on RADIO.md to `CMM Radio`.

## Campos afectados
<!-- Marca todos los campos que se modifican. Requerido. -->
* [X] Nombre
* [ ] Stream
* [ ] Web
* [ ] Logo
* [ ] EPG
* [ ] Info

## Origen de la emisión
<!-- Marca al menos una opción. Este apartado es obligatorio si añades o modificas un Stream. -->

* [ ] Sitio web oficial
* [ ] Plataforma de terceros cuyo origen es oficial
* [ ] Plataforma de terceros cuyo origen desconozco
* [ ] Origen desconocido
* [ ] Otro origen:

### Validación del Stream
<!-- Obligatorio si añades o modificas un Stream. Indica cómo has comprobado que funciona y, si es posible, en qué reproductor o dispositivo. -->

## Información adicional
<!-- Añade cualquier observación que pueda resultar útil durante la revisión. Opcional. -->

<!-- Recuerda haber leído la guía de contribuciones https://github.com/LaQuay/TDTChannels/blob/master/CONTRIBUTING.md -->
